### PR TITLE
feat(ui): service table rwd

### DIFF
--- a/app/service/_components/all-service-view.tsx
+++ b/app/service/_components/all-service-view.tsx
@@ -38,12 +38,13 @@ export default function AllServiceView({
     const date = new Date(row.date)
     const month = date.getMonth() + 1
     const year = date.getFullYear()
+    const key = `${year}-${month}`
+    acc[key] ??= []
+    acc[key].push(row)
+
     if (year < thisYear) {
       thisYear = year
     }
-    const key = `${year}-${month}`
-    acc[key] = acc[key] || []
-    acc[key].push(row)
     return acc
   }, {})
 

--- a/app/service/_components/monthly-accordion-item.tsx
+++ b/app/service/_components/monthly-accordion-item.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import { COLUMN_MAPPING, SHEET_FIELDS } from '@/app/const'
 import { AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion'
 import { Row } from '@/app/type'
 import { Button } from '@/components/ui/button'
+import { useMediaQuery } from '@/hooks/use-media-query'
+import { DesktopServiceTable, MobileServiceTable } from './service-table'
 
 export default function MonthAccordionItem({
   month,
@@ -14,55 +15,24 @@ export default function MonthAccordionItem({
   rows: Row[]
   sheetUrl: string
 }) {
+  const { isLargeDevice } = useMediaQuery()
   return (
     <AccordionItem value={`${month}`} id={`${month}`}>
       <AccordionTrigger>{month} 月服事表 </AccordionTrigger>
       <AccordionContent className="flex items-center justify-center">
-        <div className="flex flex-col gap-4 overflow-x-auto">
+        <div className="flex w-full flex-col gap-4 overflow-x-auto">
           <Button disabled={!sheetUrl} onClick={() => window.open(sheetUrl, '_blank')}>
             在 Google Sheet 表單中編輯
           </Button>
           <div className="flex overflow-x-auto">
-            <MonthServiceTable rows={rows} />
+            {isLargeDevice ? (
+              <DesktopServiceTable rows={rows} />
+            ) : (
+              <MobileServiceTable rows={rows} />
+            )}
           </div>
         </div>
       </AccordionContent>
     </AccordionItem>
-  )
-}
-
-function MonthServiceTable({ rows }: { rows: Row[] }) {
-  return (
-    <table className="relative overflow-x-auto shadow-md sm:rounded-lg">
-      <thead className="bg-gray-50 text-xs uppercase text-gray-700 dark:bg-gray-700 dark:text-gray-400">
-        <tr>
-          {SHEET_FIELDS.map((key) => (
-            <th key={key} className="px-6 py-3">
-              {COLUMN_MAPPING[key]}
-            </th>
-          ))}
-        </tr>
-      </thead>
-      <tbody>
-        {rows.map((row, index) => (
-          <ServiceTableRow key={index} row={row} />
-        ))}
-      </tbody>
-    </table>
-  )
-}
-
-function ServiceTableRow({ row }: { row: Row }) {
-  return (
-    <tr className="border-b odd:bg-white even:bg-gray-50 dark:border-gray-700 odd:dark:bg-gray-900 even:dark:bg-gray-800">
-      {SHEET_FIELDS.map((key) => (
-        <td
-          key={key}
-          className="whitespace-nowrap px-6 py-4 font-medium text-gray-900 dark:text-white"
-        >
-          {row[key]}
-        </td>
-      ))}
-    </tr>
   )
 }

--- a/app/service/_components/personal-search-bar.tsx
+++ b/app/service/_components/personal-search-bar.tsx
@@ -38,11 +38,11 @@ export default function PersonalSearchBar() {
         <div className="grid gap-4 py-4">
           <div className="grid grid-cols-4 items-center gap-4">
             <Label htmlFor="name" className="text-right">
-              你的名子
+              你的名字
             </Label>
             <Input
               id="name"
-              placeholder="請輸入名子"
+              placeholder="請輸入名字"
               defaultValue={user}
               onChange={(e) => setLocalUserName(e.target.value)}
               className="col-span-3"

--- a/app/service/_components/service-card.tsx
+++ b/app/service/_components/service-card.tsx
@@ -31,7 +31,6 @@ const createGoogleCalendarLink = (service: ServiceRecord) => {
   const text = encodeURIComponent(`${COLUMN_MAPPING[service.type]}: ${service.user}`)
   const startDateTime = formatDate(service.date, SERVICE_TIME[service.type].start)
   const endDateTime = formatDate(service.date, SERVICE_TIME[service.type].end)
-  console.log(startDateTime, endDateTime)
   const details = encodeURIComponent(SERVICE_NOTES[service.type].join('\n'))
   return `${BASE_CALENDAR_URL}&text=${text}&dates=${startDateTime}/${endDateTime}&details=${details}`
 }

--- a/app/service/_components/service-table/desktop.tsx
+++ b/app/service/_components/service-table/desktop.tsx
@@ -1,0 +1,54 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { Row } from '@/app/type'
+import { COLUMN_MAPPING, SHEET_FIELDS } from '@/app/const'
+import { cn } from '@/lib/utils'
+
+function ServiceTableRow({ row, index }: { row: Row; index: number }) {
+  return (
+    <TableRow
+      className={cn(
+        'dark:border-gray-700',
+        index % 2 === 1 ? 'bg-gray-50 dark:bg-gray-700' : 'bg-white dark:bg-gray-800'
+      )}
+    >
+      {SHEET_FIELDS.map((key) => (
+        <TableCell key={key} className="whitespace-nowrap text-center font-bold dark:text-gray-300">
+          {row[key]}
+        </TableCell>
+      ))}
+    </TableRow>
+  )
+}
+
+export default function DesktopServiceTable({ rows }: { rows: Row[] }) {
+  return (
+    <div className="w-full overflow-auto dark:bg-gray-800">
+      <Table>
+        <TableHeader>
+          <TableRow className="dark:border-gray-700">
+            {SHEET_FIELDS.map((key) => (
+              <TableHead
+                key={key}
+                className="whitespace-nowrap bg-gray-100 text-center font-bold dark:bg-gray-900 dark:text-gray-200"
+              >
+                {COLUMN_MAPPING[key]}
+              </TableHead>
+            ))}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {rows.map((row, index) => (
+            <ServiceTableRow key={index} row={row} index={index} />
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}

--- a/app/service/_components/service-table/index.tsx
+++ b/app/service/_components/service-table/index.tsx
@@ -1,0 +1,2 @@
+export { default as DesktopServiceTable } from './desktop'
+export { default as MobileServiceTable } from './mobile'

--- a/app/service/_components/service-table/mobile.tsx
+++ b/app/service/_components/service-table/mobile.tsx
@@ -1,0 +1,75 @@
+import { Row } from '@/app/type'
+import { COLUMN_MAPPING, SHEET_FIELDS } from '@/app/const'
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { useState } from 'react'
+import { addDays, startOfWeek } from 'date-fns'
+import { cn, safeFormatDate } from '@/lib/utils'
+
+interface MobileServiceTableProps {
+  rows: Row[]
+}
+
+export default function MobileServiceTable({ rows }: MobileServiceTableProps) {
+  const thisWeekStart = startOfWeek(new Date(), { weekStartsOn: 1 })
+  const thisWeekEnd = addDays(thisWeekStart, 6)
+  const defaultSelectDate =
+    rows.find(({ date }) => {
+      const rowDate = new Date(date)
+      return rowDate >= thisWeekStart && rowDate <= thisWeekEnd
+    })?.date ?? rows[0].date
+  const [selectedDate, setSelectedDate] = useState<string>(defaultSelectDate)
+  const selectedRow = rows.find(({ date }) => date === selectedDate)
+
+  return (
+    <div className="w-full space-y-4">
+      <div className="mb-4 flex flex-wrap gap-2">
+        {rows.map(({ date }) => (
+          <Button
+            key={date}
+            onClick={() => setSelectedDate(date)}
+            variant={selectedDate === date ? 'default' : 'outline'}
+            className={cn(
+              'rounded-full',
+              selectedDate === date
+                ? 'bg-green-500 text-white hover:bg-green-600 dark:bg-green-600 dark:text-white dark:hover:bg-green-700'
+                : 'bg-background text-foreground hover:bg-accent hover:text-accent-foreground dark:bg-background dark:text-foreground dark:hover:bg-accent dark:hover:text-accent-foreground'
+            )}
+          >
+            {safeFormatDate(date, 'MM月d日')}
+          </Button>
+        ))}
+      </div>
+      {selectedRow && <ServiceCard row={selectedRow} />}
+    </div>
+  )
+}
+
+function ServiceCard({ row }: { row: Row }) {
+  return (
+    <Card className="mb-4 w-full border-gray-200 dark:border-gray-600">
+      <CardHeader className="bg-white dark:bg-gray-800">
+        <CardTitle className="truncate text-center font-bold text-gray-800 dark:text-gray-200">
+          {safeFormatDate(row[SHEET_FIELDS[0]], 'MM月d日')}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-0">
+        <div className="divide-y divide-gray-200 dark:divide-gray-600">
+          {SHEET_FIELDS.slice(1).map((key, index) => (
+            <div
+              key={key}
+              className={`flex px-4 py-2 ${index % 2 === 0 ? 'bg-white dark:bg-gray-800' : 'bg-gray-100 dark:bg-gray-700'}`}
+            >
+              <div className="w-1/2 text-left font-bold text-gray-600 dark:text-gray-400">
+                {COLUMN_MAPPING[key]}
+              </div>
+              <div className="w-1/2 break-words text-left font-bold text-gray-800 dark:text-gray-200">
+                {row[key]}
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/components/ui/table.tsx
+++ b/components/ui/table.tsx
@@ -1,0 +1,91 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
+  ({ className, ...props }, ref) => (
+    <div className="relative w-full overflow-auto">
+      <table ref={ref} className={cn('w-full caption-bottom text-sm', className)} {...props} />
+    </div>
+  )
+)
+Table.displayName = 'Table'
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn('[&_tr]:border-b', className)} {...props} />
+))
+TableHeader.displayName = 'TableHeader'
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody ref={ref} className={cn('[&_tr:last-child]:border-0', className)} {...props} />
+))
+TableBody.displayName = 'TableBody'
+
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn('border-t bg-muted/50 font-medium [&>tr]:last:border-b-0', className)}
+    {...props}
+  />
+))
+TableFooter.displayName = 'TableFooter'
+
+const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
+  ({ className, ...props }, ref) => (
+    <tr
+      ref={ref}
+      className={cn(
+        'border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted',
+        className
+      )}
+      {...props}
+    />
+  )
+)
+TableRow.displayName = 'TableRow'
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      'h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0',
+      className
+    )}
+    {...props}
+  />
+))
+TableHead.displayName = 'TableHead'
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn('p-4 align-middle [&:has([role=checkbox])]:pr-0', className)}
+    {...props}
+  />
+))
+TableCell.displayName = 'TableCell'
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption ref={ref} className={cn('mt-4 text-sm text-muted-foreground', className)} {...props} />
+))
+TableCaption.displayName = 'TableCaption'
+
+export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption }

--- a/hooks/use-media-query.ts
+++ b/hooks/use-media-query.ts
@@ -1,0 +1,19 @@
+import { useMediaQuery as useMediaQueryHook } from '@uidotdev/usehooks'
+
+const breakpoints = {
+  small: 'only screen and (max-width : 768px)',
+  medium: 'only screen and (min-width : 769px) and (max-width : 1200px)',
+  large: 'only screen and (min-width : 1201px)',
+}
+
+export function useMediaQuery() {
+  const isSmallDevice = useMediaQueryHook(breakpoints.small)
+  const isMediumDevice = useMediaQueryHook(breakpoints.medium)
+  const isLargeDevice = useMediaQueryHook(breakpoints.large)
+
+  return {
+    isSmallDevice,
+    isMediumDevice,
+    isLargeDevice,
+  }
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,4 +1,5 @@
 import { type ClassValue, clsx } from 'clsx'
+import { format, isValid } from 'date-fns'
 import { twMerge } from 'tailwind-merge'
 
 /**
@@ -20,4 +21,17 @@ export function generateQueryString(name: string, value: string) {
   const params = new URLSearchParams()
   params.set(name, value)
   return params.toString()
+}
+
+/**
+ * 安全地格式化日期
+ * @description 如果輸入是有效日期，則使用 date-fns 的 format 函數進行格式化；否則返回原始輸入[並轉成字串]
+ * @param params format 函數的參數
+ * @returns 格式化後的日期字符串或原始輸入
+ */
+export function safeFormatDate(...params: Parameters<typeof format>): ReturnType<typeof format> {
+  const [originalDate] = params
+  const date = originalDate instanceof Date ? originalDate : new Date(originalDate)
+
+  return isValid(date) ? format(...params) : `${originalDate}`
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@tanstack/react-query": "^5.53.1",
         "@tanstack/react-query-devtools": "^5.53.1",
         "@tanstack/react-query-persist-client": "^5.53.3",
+        "@uidotdev/usehooks": "^2.4.1",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
         "date-fns": "^3.3.1",
@@ -4894,6 +4895,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@uidotdev/usehooks": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@uidotdev/usehooks/-/usehooks-2.4.1.tgz",
+      "integrity": "sha512-1I+RwWyS+kdv3Mv0Vmc+p0dPYH0DTRAo04HLyXReYBL9AeseDWUJyi4THuksBJcu9F0Pih69Ak150VDnqbVnXg==",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
       }
     },
     "node_modules/@ungap/structured-clone": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@tanstack/react-query": "^5.53.1",
     "@tanstack/react-query-devtools": "^5.53.1",
     "@tanstack/react-query-persist-client": "^5.53.3",
+    "@uidotdev/usehooks": "^2.4.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "date-fns": "^3.3.1",


### PR DESCRIPTION
close #65 
1. 引入 shadcn ui 的 table 改寫原本的 desktop 版本 Table
2. 建立 mobile table，直立顯示 table，並將該月份的 table 上方新增 button，點擊目標日期的 button 會顯示對應的 mobile table，減少滑太久的困擾