### PR TITLE
feat: improve Google Sheet data fetching

### DIFF
--- a/app/api/google-sheet/utility.ts
+++ b/app/api/google-sheet/utility.ts
@@ -3,50 +3,49 @@ import { google } from 'googleapis'
 import { COLUMN_MAPPING_REVERSE } from '@/app/const'
 import { GoogleSheetResponse, GoogleSheetYear, Row } from '@/app/type'
 
+interface GoogleSheetClientConfig {
+  clientEmail?: string
+  privateKey?: string
+  driveEndpoint?: string
+}
+
+const SHEET_RANGE = '總表!A:V'
 /**
  * Fetches data from a Google Sheet and processes it into a structured format.
  * @returns {Promise<GoogleSheetResponse>} A promise that resolves to the processed sheet data.
  */
 export async function fetchGoogleSheetData(): Promise<GoogleSheetResponse> {
-  // Validate environment variables
-  const clientEmail = process.env.GOOGLE_CLIENT_EMAIL
-  const privateKey = process.env.GOOGLE_PRIVATE_KEY?.replace(/\\n/g, '\n')
-  const driveEndpoint = process.env.GOOGLE_DRIVE_ENDPOINT || ''
-
-  if (!clientEmail || !privateKey || !driveEndpoint) {
-    throw new Error('Missing required environment variables for Google Sheets API')
-  }
-  // Initialize Google Auth client
-  const client = new google.auth.JWT(clientEmail, undefined, privateKey, [driveEndpoint])
-
-  const SHEET_RANGE = '總表!A:V'
-
-  // Create Google Sheets API client
-  const sheetClient = google.sheets({ version: 'v4', auth: client })
-
-  // Fetch raw data from the Google Sheet
-  const {
-    data: { values: currentYearValues },
-  } = await sheetClient.spreadsheets.values.get({
-    spreadsheetId: process.env.MAIN_SPREAD_SHEET_ID,
-    range: SHEET_RANGE,
-  })
-
-  // Destructure the values array, separating header row from data rows
-  const [, headerRow, ...thisYearRestRows] = currentYearValues as string[][]
-
-  // Get the rest of the rows from the next year's sheet
-  let restRows = thisYearRestRows
-  if (process.env.NEXT_YEAR_SPREAD_SHEET_ID) {
-    const {
-      data: { values: nextYearValues },
-    } = await sheetClient.spreadsheets.values.get({
-      spreadsheetId: process.env.NEXT_YEAR_SPREAD_SHEET_ID,
+  const sheetClient = createGoogleSheetClient()
+  const [currentYearResponse, nextYearResponse] = await Promise.all([
+    sheetClient.spreadsheets.values.get({
+      spreadsheetId: process.env.MAIN_SPREAD_SHEET_ID,
       range: SHEET_RANGE,
-    })
-    const [, , ...nextYearRestRows] = nextYearValues as string[][]
-    restRows = [...thisYearRestRows, ...nextYearRestRows]
-  }
+    }),
+    process.env.NEXT_YEAR_SPREAD_SHEET_ID
+      ? sheetClient.spreadsheets.values.get({
+          spreadsheetId: process.env.NEXT_YEAR_SPREAD_SHEET_ID,
+          range: SHEET_RANGE,
+        })
+      : void 0,
+  ])
+  Object.entries({ currentYearResponse, nextYearResponse }).forEach(([label, response]) => {
+    // Skip if null or undefined (no next year ID)
+    if (!response) return
+    const { data: { values = [] } = {} } = response
+    if (!Array.isArray(values) || values.length === 0) {
+      throw new Error(
+        '未正確取得 Google Sheet 資料：' +
+          JSON.stringify({
+            [label]: response,
+          })
+      )
+    }
+  })
+  // Destructure the values array, separating header row from data rows
+  const [, headerRow, ...thisYearRestRows] = currentYearResponse.data.values as string[][]
+  const [, , ...nextYearRestRows] = (nextYearResponse?.data.values ?? []) as string[][]
+  // Get the rest of the rows from the next year's sheet
+  const restRows = [...thisYearRestRows, ...nextYearRestRows]
 
   // Process the raw data
   const data = restRows
@@ -66,6 +65,25 @@ export async function fetchGoogleSheetData(): Promise<GoogleSheetResponse> {
     .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
 
   return { data }
+}
+
+function createGoogleSheetClient({
+  clientEmail = process.env.GOOGLE_CLIENT_EMAIL ?? '',
+  privateKey = process.env.GOOGLE_PRIVATE_KEY?.replace(/\\n/g, '\n') ?? '',
+  driveEndpoint = process.env.GOOGLE_DRIVE_ENDPOINT ?? '',
+}: GoogleSheetClientConfig = {}) {
+  if (!clientEmail || !privateKey || !driveEndpoint) {
+    throw new Error(
+      '缺少必要的 Google Sheets API 環境變數：' +
+        JSON.stringify({
+          clientEmail: clientEmail ? '已設定' : '未設定',
+          privateKey: privateKey ? '已設定' : '未設定',
+          driveEndpoint: driveEndpoint ? '已設定' : '未設定',
+        })
+    )
+  }
+  const client = new google.auth.JWT(clientEmail, undefined, privateKey, [driveEndpoint])
+  return google.sheets({ version: 'v4', auth: client })
 }
 
 export function getSheetUrl(year: GoogleSheetYear) {

--- a/app/service/_hooks/useGoogleSheet.ts
+++ b/app/service/_hooks/useGoogleSheet.ts
@@ -1,13 +1,26 @@
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { fetchGoogleSheetData } from '@/app/api/client'
 import { QUERY_KEY } from '@/app/const'
+import { captureMessage } from '@sentry/nextjs'
 
 export default function useGoogleSheet() {
+  const queryClient = useQueryClient()
   const query = useQuery({
     queryKey: [QUERY_KEY.GOOGLE_SHEET],
     queryFn: fetchGoogleSheetData,
     throwOnError: true,
-    select: (data) => data.data,
+    select: (data) => {
+      const sheetData = data?.data
+      const isSheetDataValid = Array.isArray(sheetData)
+      if (!isSheetDataValid) {
+        const cachedSheetData = queryClient.getQueryData([QUERY_KEY.GOOGLE_SHEET])
+        captureMessage('Google Sheet data is not an array', {
+          extra: { sheetData, cachedGoogleSheetData: cachedSheetData },
+          level: 'error',
+        })
+      }
+      return isSheetDataValid ? sheetData : []
+    },
     retry: 3,
     retryDelay: 1000,
   })

--- a/app/service/page.tsx
+++ b/app/service/page.tsx
@@ -10,7 +10,7 @@ import { useUserStore } from '@/stores/useUserStore'
 import { useEffect } from 'react'
 
 export default function ServicesPage() {
-  const { data: sheetData, isLoading, isSuccess } = useGoogleSheet()
+  const { data: sheetData = [], isLoading, isSuccess } = useGoogleSheet()
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()


### PR DESCRIPTION
猜測是 android 使用 React Query 的 cache 時可能發生了錯誤
因為  `'api/google-sheet'` 回傳必定是陣列，若不是中間處理就會噴錯，故加強 `useGoogleSheet` 的邏輯，使回傳的資料必定為陣列
closed: Occational Issue on Page Load #225