### PR TITLE
fix(deploy): build standalone with webpack to fix GAE deploy crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack -H 0.0.0.0",
-    "build": "next build",
+    "build": "next build --webpack",
     "start": "next start",
     "lint": "eslint --fix app components lib providers stores hooks && tsc",
     "prepare": "husky"


### PR DESCRIPTION
## Problem
After the Next 16 upgrade (#448), the GAE release deploy crashes:

```
gcloud crashed (FileNotFoundError):
  .../standalone/.next/node_modules/require-in-the-middle-2ca7b9c2766f317e
```

## Root cause
Next 16 makes **Turbopack the default builder** for `next build`. In a standalone build, Turbopack emits hashed symlinks under `.next/standalone/.next/node_modules/` — e.g. `require-in-the-middle-<hash>` and `import-in-the-middle-<hash>` (pulled in by `@sentry/nextjs`) — pointing at `../../node_modules/...`.

The release action (`​.github/actions/release`) then runs `mv node_modules node_module_hack` (the trick that smuggles our traced modules past GAE). That rename leaves the Turbopack symlinks **dangling**, and `gcloud app deploy` crashes while walking them during upload. Next 15.5 didn't emit these symlinks, so the regression appeared with #448.

## Fix
Build the production bundle with `next build --webpack`. This is the documented workaround for the Turbopack standalone behavior ([vercel/next.js#87737](https://github.com/vercel/next.js/issues/87737)) and produces the Next 15-style standalone output with **no `.next/node_modules` symlinks**. It also keeps **next-pwa** working, since that is a webpack plugin.

Dev (`next dev --turbopack`) is unchanged.

## Verified locally
- `next build` (Turbopack, default): 2 dangling-prone symlinks in `.next/standalone/.next/node_modules` → reproduces the crash condition
- `next build --webpack`: **0 symlinks**, no `.next/node_modules` dir, `public/sw.js` still generated by next-pwa, build exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)